### PR TITLE
Fixes stop scan

### DIFF
--- a/beckon/src/main/java/com/technocreatives/beckon/internal/BeckonClientImpl.kt
+++ b/beckon/src/main/java/com/technocreatives/beckon/internal/BeckonClientImpl.kt
@@ -44,14 +44,9 @@ internal class BeckonClientImpl(
     }
 
     override suspend fun stopScan() {
-        Timber.w("Execute stopScan")
-        if (beckonStore.currentState().bluetoothState == BluetoothState.ON) {
-            scanner?.stopScan()
-            scanner = null
-        } else {
-            // TODO Callback to application? Notify failure
-            Timber.e("Stopped scan but adapter is not turned on!")
-        }
+        Timber.w("Execute stopScan, bluetoothState: ${beckonStore.currentState().bluetoothState}")
+        scanner?.stopScan()
+        scanner = null
     }
 
     override suspend fun disconnectAllConnectedButNotSavedDevices(): Either<ConnectionError.DisconnectDeviceFailed, Unit> {


### PR DESCRIPTION
On a Pixel 6 (possibly true for other device as well) a scan can be running even though the bluetooth adapter reports as off. 

E.g 
startScan
disable bluetooth on device
(scan is still running)
adapter goes to state TURNING_OFF
(scan is still running)
adpater goes to state OFF
(scan is still running)
unable to stopScan of device due to adapter not being in state "ON"